### PR TITLE
Update main.yml

### DIFF
--- a/ansible/roles/atmo-user-ssh-keys/tasks/main.yml
+++ b/ansible/roles/atmo-user-ssh-keys/tasks/main.yml
@@ -5,7 +5,7 @@
   when: USERSSHKEYS is defined
 
 - name: Add users ssh keys to authorized_keys to home directory of user
-  authorized_key: user={{ ATMOUSERNAME }} key='{{ USERSSHKEYS|join("\n") }}' state=present exclusive=yes
+  authorized_key: user={{ ATMOUSERNAME }} key='{{ USERSSHKEYS|join("\n") }}' state=present exclusive=no
   when: USERSSHKEYS is defined
 
 - name: grab local copy of user ssh private key


### PR DESCRIPTION
set exclusive=no on authorized_key module call so that this doesn't wipe out the SSH key used by Gate One
