### PR TITLE
Remove check that a host named 'shell' can SSH to the instance

### DIFF
--- a/ansible/roles/atmo-check-novnc/tasks/main.yml
+++ b/ansible/roles/atmo-check-novnc/tasks/main.yml
@@ -89,12 +89,12 @@
     - novnc
     - check-novnc
 
-- name: fail if shell can't talk to vm
-  wait_for: >
-    search_regex=OpenSSH
-    port={{ ansible_port }}
-    host={{ ansible_host }}
-    delay=1
-    timeout={{ SSH_PORT_TIMEOUT }}
-  tags: gateone_networking_check
-  delegate_to: shell
+# - name: fail if shell can't talk to vm
+#   wait_for: >
+#     search_regex=OpenSSH
+#     port={{ ansible_port }}
+#     host={{ ansible_host }}
+#     delay=1
+#     timeout={{ SSH_PORT_TIMEOUT }}
+#   tags: gateone_networking_check
+#   delegate_to: shell


### PR DESCRIPTION
See where this was done upstream:
https://github.com/cyverse/atmosphere-ansible/commit/1ba7485309458be7e40a8ce58e1b2b1d4468206a

It's not safe to assume that a server named "shell" can create an SSH session to the instance.
My NoVNC gateway server may not exist on a server named shell.

There's probably a better way to do this but I don't have it in mind right now.