### PR TITLE
Set defaults for atmo-ntp role

### DIFF
--- a/ansible/roles/atmo-ntp/defaults/main.yml
+++ b/ansible/roles/atmo-ntp/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+
+NTP_SERVERS:
+    - server 0.us.pool.ntp.org
+    - server 1.us.pool.ntp.org
+    - server 2.us.pool.ntp.org
+    - server 3.us.pool.ntp.org


### PR DESCRIPTION
This is not required for the fix but it is a good default to set ntp when no other configuration is present.